### PR TITLE
Add JMS table connector skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# flink-jms-table-connector
+# Flink JMS Table Connector
+
+This project contains a very small proof-of-concept implementation of a JMS table connector for [Apache Flink](https://flink.apache.org/). It shows how a custom table source and sink could be wired using Flink's `DynamicTableFactory` interfaces.
+
+The implementation is intentionally minimal and does not include a real JMS consumer or producer. It is meant as a starting point for integrating a JMS queue with Flink SQL. The factory registers under the identifier `jms` so you can define a table like:
+
+```sql
+CREATE TABLE ibm_mq (
+  field1 STRING,
+  field2 INT
+) WITH (
+  'connector'                    = 'jms',
+  'jms.initial-context-factory'  = 'com.ibm.mq.jms.context.WMQInitialContextFactory',
+  'jms.provider-url'             = 'mq://host:1414/QMGR',
+  'jms.destination'              = 'MY.QUEUE',
+  'format'                       = 'json'
+);
+```
+
+To turn this into a functional connector you would need to implement JMS consumer and producer logic inside `JmsDynamicSource` and `JmsDynamicSink`.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,26 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>flink-jms-table-connector</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <name>Flink JMS Table Connector</name>
+  <description>Simple JMS table connector for Apache Flink</description>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-table-api-java</artifactId>
+      <version>1.17.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-table-planner</artifactId>
+      <version>1.17.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.jms</groupId>
+      <artifactId>jakarta.jms-api</artifactId>
+      <version>3.0.0</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/main/java/com/example/jms/JmsDynamicSink.java
+++ b/src/main/java/com/example/jms/JmsDynamicSink.java
@@ -1,0 +1,40 @@
+package com.example.jms;
+
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.sink.SinkFunctionProvider;
+import org.apache.flink.table.connector.sink.DynamicTableSink.SinkRuntimeProvider;
+import org.apache.flink.table.types.DataType;
+
+/**
+ * Simple JMS table sink skeleton.
+ */
+public class JmsDynamicSink implements DynamicTableSink {
+
+    private final DataType consumedDataType;
+
+    public JmsDynamicSink(DataType consumedDataType) {
+        this.consumedDataType = consumedDataType;
+    }
+
+    @Override
+    public ChangelogMode getChangelogMode(ChangelogMode requestedMode) {
+        return ChangelogMode.insertOnly();
+    }
+
+    @Override
+    public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
+        // TODO: create JMS producer here and return SinkFunction provider
+        return SinkFunctionProvider.of(null);
+    }
+
+    @Override
+    public DynamicTableSink copy() {
+        return new JmsDynamicSink(consumedDataType);
+    }
+
+    @Override
+    public String asSummaryString() {
+        return "JMS Table Sink";
+    }
+}

--- a/src/main/java/com/example/jms/JmsDynamicSource.java
+++ b/src/main/java/com/example/jms/JmsDynamicSource.java
@@ -1,0 +1,44 @@
+package com.example.jms;
+
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.format.DecodingFormat;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.ScanRuntimeProvider;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+
+/**
+ * Simple JMS table source skeleton.
+ */
+public class JmsDynamicSource implements ScanTableSource {
+
+    private final DecodingFormat<?> decodingFormat;
+    private final DataType producedDataType;
+
+    public JmsDynamicSource(DecodingFormat<?> decodingFormat, DataType producedDataType) {
+        this.decodingFormat = decodingFormat;
+        this.producedDataType = producedDataType;
+    }
+
+    @Override
+    public ChangelogMode getChangelogMode() {
+        return ChangelogMode.insertOnly();
+    }
+
+    @Override
+    public ScanRuntimeProvider getScanRuntimeProvider(ScanContext runtimeProviderContext) {
+        // TODO: create JMS consumer here and return SourceFunction provider
+        return null;
+    }
+
+    @Override
+    public DynamicTableSource copy() {
+        return new JmsDynamicSource(decodingFormat, producedDataType);
+    }
+
+    @Override
+    public String asSummaryString() {
+        return "JMS Table Source";
+    }
+}

--- a/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -1,0 +1,1 @@
+com.example.jms.JmsTableFactory


### PR DESCRIPTION
## Summary
- start a minimal Maven module for a JMS table connector
- implement `JmsTableFactory`, `JmsDynamicSource`, and `JmsDynamicSink`
- register the factory via `META-INF/services`
- expand README with example usage

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6851ad987ffc8321b5eeb7912face2f1