### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM maven:3.9.6-eclipse-temurin-17 AS build
+WORKDIR /build
+COPY pom.xml .
+COPY src ./src
+RUN mvn -q package -DskipTests
+
+FROM flink:1.17.1-scala_2.12-java17
+WORKDIR /opt/flink
+COPY --from=build /build/target/flink-jms-table-connector-*.jar /opt/flink/usrlib/
+COPY sql-script.sql /opt/flink/sql-script.sql
+CMD ["bash", "-c", "./bin/start-cluster.sh && ./bin/sql-client.sh -f /opt/flink/sql-script.sql"]

--- a/sql-script.sql
+++ b/sql-script.sql
@@ -1,0 +1,13 @@
+CREATE TABLE example_jms (
+  field1 STRING,
+  field2 INT
+) WITH (
+  'connector' = 'jms',
+  'jms.initial-context-factory' = 'com.example.ContextFactory',
+  'jms.provider-url' = 'mq://localhost:1414',
+  'jms.destination' = 'MY.QUEUE',
+  'format' = 'json'
+);
+
+-- run a simple query
+SHOW TABLES;


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile to build the connector
- bundle Flink SQL Gateway startup and run a demo script

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6851b062420c8321980a95209f50f19e