### PR TITLE
Fix JMS connector to accept format option

### DIFF
--- a/src/main/java/com/example/jms/JmsTableFactory.java
+++ b/src/main/java/com/example/jms/JmsTableFactory.java
@@ -52,7 +52,9 @@ public class JmsTableFactory implements DynamicTableSourceFactory, DynamicTableS
 
     @Override
     public Set<ConfigOption<?>> optionalOptions() {
-        return Set.of();
+        // Allow specifying a data format such as 'json'
+        // so users can define 'format' in the WITH clause.
+        return Set.of(FactoryUtil.FORMAT);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- allow the JMS table factory to accept the `format` option

## Testing
- `mvn -q package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6851dcbde8f883218c1568f928ddfe57