### PR TITLE
Implement basic JMS runtime functions

### DIFF
--- a/src/main/java/com/example/jms/JmsDynamicSink.java
+++ b/src/main/java/com/example/jms/JmsDynamicSink.java
@@ -4,6 +4,7 @@ import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.table.connector.format.EncodingFormat;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
+import com.example.jms.JmsSinkFunction;
 import org.apache.flink.table.connector.sink.SinkFunctionProvider;
 import org.apache.flink.table.connector.sink.DynamicTableSink.SinkRuntimeProvider;
 import org.apache.flink.table.data.RowData;
@@ -16,12 +17,21 @@ public class JmsDynamicSink implements DynamicTableSink {
 
     private final EncodingFormat<SerializationSchema<RowData>> encodingFormat;
     private final DataType consumedDataType;
+    private final String contextFactory;
+    private final String providerUrl;
+    private final String destination;
 
     public JmsDynamicSink(
             EncodingFormat<SerializationSchema<RowData>> encodingFormat,
-            DataType consumedDataType) {
+            DataType consumedDataType,
+            String contextFactory,
+            String providerUrl,
+            String destination) {
         this.encodingFormat = encodingFormat;
         this.consumedDataType = consumedDataType;
+        this.contextFactory = contextFactory;
+        this.providerUrl = providerUrl;
+        this.destination = destination;
     }
 
     @Override
@@ -31,13 +41,19 @@ public class JmsDynamicSink implements DynamicTableSink {
 
     @Override
     public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
-        // TODO: create JMS producer here and return SinkFunction provider
-        return SinkFunctionProvider.of(null);
+        SerializationSchema<RowData> serializer =
+                encodingFormat.createRuntimeEncoder(context, consumedDataType);
+
+        JmsSinkFunction sinkFunction =
+                new JmsSinkFunction(serializer, contextFactory, providerUrl, destination);
+
+        return SinkFunctionProvider.of(sinkFunction);
     }
 
     @Override
     public DynamicTableSink copy() {
-        return new JmsDynamicSink(encodingFormat, consumedDataType);
+        return new JmsDynamicSink(
+                encodingFormat, consumedDataType, contextFactory, providerUrl, destination);
     }
 
     @Override

--- a/src/main/java/com/example/jms/JmsDynamicSource.java
+++ b/src/main/java/com/example/jms/JmsDynamicSource.java
@@ -3,8 +3,10 @@ package com.example.jms;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.table.connector.format.DecodingFormat;
+import com.example.jms.JmsSourceFunction;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.connector.source.SourceFunctionProvider;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
 
@@ -15,12 +17,21 @@ public class JmsDynamicSource implements ScanTableSource {
 
     private final DecodingFormat<DeserializationSchema<RowData>> decodingFormat;
     private final DataType producedDataType;
+    private final String contextFactory;
+    private final String providerUrl;
+    private final String destination;
 
     public JmsDynamicSource(
             DecodingFormat<DeserializationSchema<RowData>> decodingFormat,
-            DataType producedDataType) {
+            DataType producedDataType,
+            String contextFactory,
+            String providerUrl,
+            String destination) {
         this.decodingFormat = decodingFormat;
         this.producedDataType = producedDataType;
+        this.contextFactory = contextFactory;
+        this.providerUrl = providerUrl;
+        this.destination = destination;
     }
 
     @Override
@@ -31,13 +42,19 @@ public class JmsDynamicSource implements ScanTableSource {
     @Override
     public ScanTableSource.ScanRuntimeProvider getScanRuntimeProvider(
             ScanTableSource.ScanContext runtimeProviderContext) {
-        // TODO: create JMS consumer here and return SourceFunction provider
-        return null;
+        DeserializationSchema<RowData> deserializer =
+                decodingFormat.createRuntimeDecoder(runtimeProviderContext, producedDataType);
+
+        JmsSourceFunction sourceFunction =
+                new JmsSourceFunction(deserializer, contextFactory, providerUrl, destination);
+
+        return SourceFunctionProvider.of(sourceFunction, false);
     }
 
     @Override
     public DynamicTableSource copy() {
-        return new JmsDynamicSource(decodingFormat, producedDataType);
+        return new JmsDynamicSource(
+                decodingFormat, producedDataType, contextFactory, providerUrl, destination);
     }
 
     @Override

--- a/src/main/java/com/example/jms/JmsSinkFunction.java
+++ b/src/main/java/com/example/jms/JmsSinkFunction.java
@@ -1,0 +1,72 @@
+package com.example.jms;
+
+import java.util.Properties;
+
+import jakarta.jms.BytesMessage;
+import jakarta.jms.Connection;
+import jakarta.jms.ConnectionFactory;
+import jakarta.jms.Destination;
+import jakarta.jms.MessageProducer;
+import jakarta.jms.Session;
+import jakarta.naming.Context;
+import jakarta.naming.InitialContext;
+
+import org.apache.flink.api.common.functions.RichSinkFunction;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.data.RowData;
+
+/**
+ * A simple JMS sink function that writes {@link RowData} records to a JMS destination.
+ */
+public class JmsSinkFunction extends RichSinkFunction<RowData> {
+
+    private final SerializationSchema<RowData> serializer;
+    private final String contextFactory;
+    private final String providerUrl;
+    private final String destinationName;
+
+    private transient Connection connection;
+    private transient Session session;
+    private transient MessageProducer producer;
+
+    public JmsSinkFunction(
+            SerializationSchema<RowData> serializer,
+            String contextFactory,
+            String providerUrl,
+            String destinationName) {
+        this.serializer = serializer;
+        this.contextFactory = contextFactory;
+        this.providerUrl = providerUrl;
+        this.destinationName = destinationName;
+    }
+
+    @Override
+    public void open(Configuration parameters) throws Exception {
+        Properties props = new Properties();
+        props.setProperty(Context.INITIAL_CONTEXT_FACTORY, contextFactory);
+        props.setProperty(Context.PROVIDER_URL, providerUrl);
+        Context ctx = new InitialContext(props);
+        ConnectionFactory factory = (ConnectionFactory) ctx.lookup("ConnectionFactory");
+        Destination destination = (Destination) ctx.lookup(destinationName);
+        connection = factory.createConnection();
+        session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+        producer = session.createProducer(destination);
+        connection.start();
+    }
+
+    @Override
+    public void invoke(RowData value, Context context) throws Exception {
+        byte[] bytes = serializer.serialize(value);
+        BytesMessage message = session.createBytesMessage();
+        message.writeBytes(bytes);
+        producer.send(message);
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (connection != null) {
+            connection.close();
+        }
+    }
+}

--- a/src/main/java/com/example/jms/JmsSourceFunction.java
+++ b/src/main/java/com/example/jms/JmsSourceFunction.java
@@ -1,0 +1,93 @@
+package com.example.jms;
+
+import java.util.Properties;
+
+import jakarta.jms.BytesMessage;
+import jakarta.jms.Connection;
+import jakarta.jms.ConnectionFactory;
+import jakarta.jms.Destination;
+import jakarta.jms.Message;
+import jakarta.jms.MessageConsumer;
+import jakarta.jms.Session;
+import jakarta.naming.Context;
+import jakarta.naming.InitialContext;
+
+import org.apache.flink.api.common.functions.RichSourceFunction;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.data.RowData;
+
+/**
+ * A simple JMS {@link org.apache.flink.streaming.api.functions.source.SourceFunction}
+ * that converts incoming JMS messages into {@link RowData} using a provided
+ * {@link DeserializationSchema}.
+ */
+public class JmsSourceFunction extends RichSourceFunction<RowData> {
+
+    private final DeserializationSchema<RowData> deserializer;
+    private final String contextFactory;
+    private final String providerUrl;
+    private final String destinationName;
+
+    private transient Connection connection;
+    private transient Session session;
+    private transient MessageConsumer consumer;
+    private volatile boolean running = true;
+
+    public JmsSourceFunction(
+            DeserializationSchema<RowData> deserializer,
+            String contextFactory,
+            String providerUrl,
+            String destinationName) {
+        this.deserializer = deserializer;
+        this.contextFactory = contextFactory;
+        this.providerUrl = providerUrl;
+        this.destinationName = destinationName;
+    }
+
+    @Override
+    public void open(Configuration parameters) throws Exception {
+        Properties props = new Properties();
+        props.setProperty(Context.INITIAL_CONTEXT_FACTORY, contextFactory);
+        props.setProperty(Context.PROVIDER_URL, providerUrl);
+        Context ctx = new InitialContext(props);
+        ConnectionFactory factory = (ConnectionFactory) ctx.lookup("ConnectionFactory");
+        Destination destination = (Destination) ctx.lookup(destinationName);
+        connection = factory.createConnection();
+        session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+        consumer = session.createConsumer(destination);
+        connection.start();
+    }
+
+    @Override
+    public void run(SourceContext<RowData> ctx) throws Exception {
+        while (running) {
+            Message message = consumer.receive(1000);
+            if (message instanceof BytesMessage) {
+                BytesMessage bm = (BytesMessage) message;
+                byte[] bytes = new byte[(int) bm.getBodyLength()];
+                bm.readBytes(bytes);
+                RowData row = deserializer.deserialize(bytes);
+                ctx.collect(row);
+            } else if (message != null) {
+                // try to handle text messages
+                byte[] bytes = message.getBody(byte[].class);
+                if (bytes != null) {
+                    RowData row = deserializer.deserialize(bytes);
+                    ctx.collect(row);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void cancel() {
+        running = false;
+        try {
+            if (connection != null) {
+                connection.close();
+            }
+        } catch (Exception ignore) {
+        }
+    }
+}

--- a/src/main/java/com/example/jms/JmsTableFactory.java
+++ b/src/main/java/com/example/jms/JmsTableFactory.java
@@ -68,10 +68,15 @@ public class JmsTableFactory implements DynamicTableSourceFactory, DynamicTableS
 
         DataType dataType = context.getCatalogTable().getResolvedSchema().toPhysicalRowDataType();
 
+        String contextFactory = helper.getOptions().get(INITIAL_CONTEXT_FACTORY);
+        String providerUrl = helper.getOptions().get(PROVIDER_URL);
+        String destination = helper.getOptions().get(DESTINATION);
+
         // validation
         helper.validate();
 
-        return new JmsDynamicSource(decodingFormat, dataType);
+        return new JmsDynamicSource(
+                decodingFormat, dataType, contextFactory, providerUrl, destination);
     }
 
     @Override
@@ -85,9 +90,14 @@ public class JmsTableFactory implements DynamicTableSourceFactory, DynamicTableS
 
         DataType dataType = context.getCatalogTable().getResolvedSchema().toPhysicalRowDataType();
 
+        String contextFactory = helper.getOptions().get(INITIAL_CONTEXT_FACTORY);
+        String providerUrl = helper.getOptions().get(PROVIDER_URL);
+        String destination = helper.getOptions().get(DESTINATION);
+
         // validation
         helper.validate();
 
-        return new JmsDynamicSink(encodingFormat, dataType);
+        return new JmsDynamicSink(
+                encodingFormat, dataType, contextFactory, providerUrl, destination);
     }
 }


### PR DESCRIPTION
## Summary
- add simple JMS SourceFunction and SinkFunction implementations
- wire dynamic source and sink to create runtime providers
- pass JMS options through the table factory

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851e28a06e48321ad999454003744c9