### PR TITLE
Switch to flink-connector-jms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Flink JMS Table Connector
 
-This project contains a very small proof-of-concept implementation of a JMS table connector for [Apache Flink](https://flink.apache.org/). It shows how a custom table source and sink could be wired using Flink's `DynamicTableFactory` interfaces.
+This project contains a very small proof-of-concept implementation of a JMS table connector for [Apache Flink](https://flink.apache.org/). It shows how a custom table source and sink could be wired using Flink's `DynamicTableFactory` interfaces. The connector now uses the community maintained [`flink-connector-jms`](https://github.com/miwurster/flink-connector-jms) library instead of the Jakarta JMS API.
 
 The implementation is intentionally minimal and does not include a real JMS consumer or producer. It is meant as a starting point for integrating a JMS queue with Flink SQL. The factory registers under the identifier `jms` so you can define a table like:
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,14 +18,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>jakarta.jms</groupId>
-      <artifactId>jakarta.jms-api</artifactId>
-      <version>3.0.0</version>
-    </dependency>
-    <dependency>
-      <groupId>jakarta.naming</groupId>
-      <artifactId>jakarta.naming-api</artifactId>
-      <version>2.1.0</version>
+      <groupId>com.github.miwurster</groupId>
+      <artifactId>flink-connector-jms</artifactId>
+      <version>1.0.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/src/main/java/com/example/jms/JmsSinkFunction.java
+++ b/src/main/java/com/example/jms/JmsSinkFunction.java
@@ -2,13 +2,13 @@ package com.example.jms;
 
 import java.util.Properties;
 
-import jakarta.jms.BytesMessage;
-import jakarta.jms.Connection;
-import jakarta.jms.ConnectionFactory;
-import jakarta.jms.Destination;
-import jakarta.jms.MessageProducer;
-import jakarta.jms.Session;
-import jakarta.naming.InitialContext;
+import javax.jms.BytesMessage;
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.naming.InitialContext;
 
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
@@ -44,9 +44,9 @@ public class JmsSinkFunction extends RichSinkFunction<RowData> {
     @Override
     public void open(Configuration parameters) throws Exception {
         Properties props = new Properties();
-        props.setProperty(jakarta.naming.Context.INITIAL_CONTEXT_FACTORY, contextFactory);
-        props.setProperty(jakarta.naming.Context.PROVIDER_URL, providerUrl);
-        jakarta.naming.Context ctx = new InitialContext(props);
+        props.setProperty(javax.naming.Context.INITIAL_CONTEXT_FACTORY, contextFactory);
+        props.setProperty(javax.naming.Context.PROVIDER_URL, providerUrl);
+        javax.naming.Context ctx = new InitialContext(props);
         ConnectionFactory factory = (ConnectionFactory) ctx.lookup("ConnectionFactory");
         Destination destination = (Destination) ctx.lookup(destinationName);
         connection = factory.createConnection();

--- a/src/main/java/com/example/jms/JmsSourceFunction.java
+++ b/src/main/java/com/example/jms/JmsSourceFunction.java
@@ -2,15 +2,15 @@ package com.example.jms;
 
 import java.util.Properties;
 
-import jakarta.jms.BytesMessage;
-import jakarta.jms.Connection;
-import jakarta.jms.ConnectionFactory;
-import jakarta.jms.Destination;
-import jakarta.jms.Message;
-import jakarta.jms.MessageConsumer;
-import jakarta.jms.Session;
-import jakarta.naming.Context;
-import jakarta.naming.InitialContext;
+import javax.jms.BytesMessage;
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.Session;
+import javax.naming.Context;
+import javax.naming.InitialContext;
 
 import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext;


### PR DESCRIPTION
## Summary
- depend on `com.github.miwurster:flink-connector-jms`
- replace `jakarta` imports with `javax`
- mention the library in the README

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852938d3b9083219818674c3e8bc08f