### PR TITLE
Add JMS dependencies and shading

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,10 @@ CREATE TABLE ibm_mq (
 ```
 
 To turn this into a functional connector you would need to implement JMS consumer and producer logic inside `JmsDynamicSource` and `JmsDynamicSink`.
+
+When building the connector make sure that the required JMS implementation
+libraries are available at runtime.  The `pom.xml` in this repository
+uses the Maven Shade plugin so the resulting jar contains the JMS API and
+the RabbitMQ JMS client.  Copy the shaded jar into Flink's `usrlib`
+directory so the SQL client can load the connector together with the JMS
+dependencies.

--- a/pom.xml
+++ b/pom.xml
@@ -22,5 +22,39 @@
       <artifactId>flink-connector-jms</artifactId>
       <version>1.0.0</version>
     </dependency>
+    <!-- JMS API and RabbitMQ JMS provider -->
+    <dependency>
+      <groupId>javax.jms</groupId>
+      <artifactId>javax.jms-api</artifactId>
+      <version>2.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.rabbitmq.jms</groupId>
+      <artifactId>rabbitmq-jms</artifactId>
+      <version>1.15.2</version>
+    </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <!-- build an uber-jar so JMS dependencies are available in Flink -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.4.1</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>shaded</shadedClassifierName>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
## Summary
- include JMS API and RabbitMQ JMS client in `pom.xml`
- build a shaded connector JAR so all dependencies are available
- document that the shaded JAR must be copied to Flink

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685299cb69fc832195468caa8b743b14