### PR TITLE
Add JMS credential options

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,14 @@ CREATE TABLE ibm_mq (
   'jms.initial-context-factory'  = 'com.ibm.mq.jms.context.WMQInitialContextFactory',
   'jms.provider-url'             = 'mq://host:1414/QMGR',
   'jms.destination'              = 'MY.QUEUE',
+  'jms.username'                = 'myuser',
+  'jms.password'                = 'secret',
   'format'                       = 'json'
 );
 ```
+
+The `jms.username` and `jms.password` options are optional and are passed to the
+underlying JMS `ConnectionFactory` when establishing the connection.
 
 To turn this into a functional connector you would need to implement JMS consumer and producer logic inside `JmsDynamicSource` and `JmsDynamicSink`.
 

--- a/sql-script.sql
+++ b/sql-script.sql
@@ -6,6 +6,8 @@ CREATE TABLE example_jms (
   'jms.initial-context-factory' = 'com.example.ContextFactory',
   'jms.provider-url' = 'mq://localhost:1414',
   'jms.destination' = 'MY.QUEUE',
+  'jms.username' = 'myuser',
+  'jms.password' = 'secret',
   'format' = 'json'
 );
 

--- a/src/main/java/com/example/jms/JmsDynamicSink.java
+++ b/src/main/java/com/example/jms/JmsDynamicSink.java
@@ -20,18 +20,24 @@ public class JmsDynamicSink implements DynamicTableSink {
     private final String contextFactory;
     private final String providerUrl;
     private final String destination;
+    private final String username;
+    private final String password;
 
     public JmsDynamicSink(
             EncodingFormat<SerializationSchema<RowData>> encodingFormat,
             DataType consumedDataType,
             String contextFactory,
             String providerUrl,
-            String destination) {
+            String destination,
+            String username,
+            String password) {
         this.encodingFormat = encodingFormat;
         this.consumedDataType = consumedDataType;
         this.contextFactory = contextFactory;
         this.providerUrl = providerUrl;
         this.destination = destination;
+        this.username = username;
+        this.password = password;
     }
 
     @Override
@@ -45,7 +51,8 @@ public class JmsDynamicSink implements DynamicTableSink {
                 encodingFormat.createRuntimeEncoder(context, consumedDataType);
 
         JmsSinkFunction sinkFunction =
-                new JmsSinkFunction(serializer, contextFactory, providerUrl, destination);
+                new JmsSinkFunction(
+                        serializer, contextFactory, providerUrl, destination, username, password);
 
         return SinkFunctionProvider.of(sinkFunction);
     }
@@ -53,7 +60,13 @@ public class JmsDynamicSink implements DynamicTableSink {
     @Override
     public DynamicTableSink copy() {
         return new JmsDynamicSink(
-                encodingFormat, consumedDataType, contextFactory, providerUrl, destination);
+                encodingFormat,
+                consumedDataType,
+                contextFactory,
+                providerUrl,
+                destination,
+                username,
+                password);
     }
 
     @Override

--- a/src/main/java/com/example/jms/JmsDynamicSource.java
+++ b/src/main/java/com/example/jms/JmsDynamicSource.java
@@ -20,18 +20,24 @@ public class JmsDynamicSource implements ScanTableSource {
     private final String contextFactory;
     private final String providerUrl;
     private final String destination;
+    private final String username;
+    private final String password;
 
     public JmsDynamicSource(
             DecodingFormat<DeserializationSchema<RowData>> decodingFormat,
             DataType producedDataType,
             String contextFactory,
             String providerUrl,
-            String destination) {
+            String destination,
+            String username,
+            String password) {
         this.decodingFormat = decodingFormat;
         this.producedDataType = producedDataType;
         this.contextFactory = contextFactory;
         this.providerUrl = providerUrl;
         this.destination = destination;
+        this.username = username;
+        this.password = password;
     }
 
     @Override
@@ -46,7 +52,8 @@ public class JmsDynamicSource implements ScanTableSource {
                 decodingFormat.createRuntimeDecoder(runtimeProviderContext, producedDataType);
 
         JmsSourceFunction sourceFunction =
-                new JmsSourceFunction(deserializer, contextFactory, providerUrl, destination);
+                new JmsSourceFunction(
+                        deserializer, contextFactory, providerUrl, destination, username, password);
 
         return SourceFunctionProvider.of(sourceFunction, false);
     }
@@ -54,7 +61,13 @@ public class JmsDynamicSource implements ScanTableSource {
     @Override
     public DynamicTableSource copy() {
         return new JmsDynamicSource(
-                decodingFormat, producedDataType, contextFactory, providerUrl, destination);
+                decodingFormat,
+                producedDataType,
+                contextFactory,
+                providerUrl,
+                destination,
+                username,
+                password);
     }
 
     @Override

--- a/src/main/java/com/example/jms/JmsSinkFunction.java
+++ b/src/main/java/com/example/jms/JmsSinkFunction.java
@@ -25,6 +25,8 @@ public class JmsSinkFunction extends RichSinkFunction<RowData> {
     private final String contextFactory;
     private final String providerUrl;
     private final String destinationName;
+    private final String username;
+    private final String password;
 
     private transient Connection connection;
     private transient Session session;
@@ -34,11 +36,15 @@ public class JmsSinkFunction extends RichSinkFunction<RowData> {
             SerializationSchema<RowData> serializer,
             String contextFactory,
             String providerUrl,
-            String destinationName) {
+            String destinationName,
+            String username,
+            String password) {
         this.serializer = serializer;
         this.contextFactory = contextFactory;
         this.providerUrl = providerUrl;
         this.destinationName = destinationName;
+        this.username = username;
+        this.password = password;
     }
 
     @Override
@@ -49,7 +55,11 @@ public class JmsSinkFunction extends RichSinkFunction<RowData> {
         javax.naming.Context ctx = new InitialContext(props);
         ConnectionFactory factory = (ConnectionFactory) ctx.lookup("ConnectionFactory");
         Destination destination = (Destination) ctx.lookup(destinationName);
-        connection = factory.createConnection();
+        if (username != null) {
+            connection = factory.createConnection(username, password);
+        } else {
+            connection = factory.createConnection();
+        }
         session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
         producer = session.createProducer(destination);
         connection.start();

--- a/src/main/java/com/example/jms/JmsSourceFunction.java
+++ b/src/main/java/com/example/jms/JmsSourceFunction.java
@@ -29,6 +29,8 @@ public class JmsSourceFunction extends RichSourceFunction<RowData> {
     private final String contextFactory;
     private final String providerUrl;
     private final String destinationName;
+    private final String username;
+    private final String password;
 
     private transient Connection connection;
     private transient Session session;
@@ -39,11 +41,15 @@ public class JmsSourceFunction extends RichSourceFunction<RowData> {
             DeserializationSchema<RowData> deserializer,
             String contextFactory,
             String providerUrl,
-            String destinationName) {
+            String destinationName,
+            String username,
+            String password) {
         this.deserializer = deserializer;
         this.contextFactory = contextFactory;
         this.providerUrl = providerUrl;
         this.destinationName = destinationName;
+        this.username = username;
+        this.password = password;
     }
 
     @Override
@@ -54,7 +60,11 @@ public class JmsSourceFunction extends RichSourceFunction<RowData> {
         Context ctx = new InitialContext(props);
         ConnectionFactory factory = (ConnectionFactory) ctx.lookup("ConnectionFactory");
         Destination destination = (Destination) ctx.lookup(destinationName);
-        connection = factory.createConnection();
+        if (username != null) {
+            connection = factory.createConnection(username, password);
+        } else {
+            connection = factory.createConnection();
+        }
         session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
         consumer = session.createConsumer(destination);
         connection.start();

--- a/src/main/java/com/example/jms/JmsTableFactory.java
+++ b/src/main/java/com/example/jms/JmsTableFactory.java
@@ -40,6 +40,16 @@ public class JmsTableFactory implements DynamicTableSourceFactory, DynamicTableS
             .stringType()
             .noDefaultValue();
 
+    public static final ConfigOption<String> USERNAME = ConfigOptions
+            .key("jms.username")
+            .stringType()
+            .noDefaultValue();
+
+    public static final ConfigOption<String> PASSWORD = ConfigOptions
+            .key("jms.password")
+            .stringType()
+            .noDefaultValue();
+
     @Override
     public String factoryIdentifier() {
         return IDENTIFIER;
@@ -54,7 +64,7 @@ public class JmsTableFactory implements DynamicTableSourceFactory, DynamicTableS
     public Set<ConfigOption<?>> optionalOptions() {
         // Allow specifying a data format such as 'json'
         // so users can define 'format' in the WITH clause.
-        return Set.of(FactoryUtil.FORMAT);
+        return Set.of(FactoryUtil.FORMAT, USERNAME, PASSWORD);
     }
 
     @Override
@@ -71,12 +81,20 @@ public class JmsTableFactory implements DynamicTableSourceFactory, DynamicTableS
         String contextFactory = helper.getOptions().get(INITIAL_CONTEXT_FACTORY);
         String providerUrl = helper.getOptions().get(PROVIDER_URL);
         String destination = helper.getOptions().get(DESTINATION);
+        String username = helper.getOptions().get(USERNAME);
+        String password = helper.getOptions().get(PASSWORD);
 
         // validation
         helper.validate();
 
         return new JmsDynamicSource(
-                decodingFormat, dataType, contextFactory, providerUrl, destination);
+                decodingFormat,
+                dataType,
+                contextFactory,
+                providerUrl,
+                destination,
+                username,
+                password);
     }
 
     @Override
@@ -93,11 +111,19 @@ public class JmsTableFactory implements DynamicTableSourceFactory, DynamicTableS
         String contextFactory = helper.getOptions().get(INITIAL_CONTEXT_FACTORY);
         String providerUrl = helper.getOptions().get(PROVIDER_URL);
         String destination = helper.getOptions().get(DESTINATION);
+        String username = helper.getOptions().get(USERNAME);
+        String password = helper.getOptions().get(PASSWORD);
 
         // validation
         helper.validate();
 
         return new JmsDynamicSink(
-                encodingFormat, dataType, contextFactory, providerUrl, destination);
+                encodingFormat,
+                dataType,
+                contextFactory,
+                providerUrl,
+                destination,
+                username,
+                password);
     }
 }


### PR DESCRIPTION
## Summary
- add `jms.username` and `jms.password` options
- plumb username/password through factory, source, and sink classes
- open JMS connections with credentials when configured
- document options and update SQL example

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ceb53a64832183c951b088369d13