### PR TITLE
Update to Jakarta JMS API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Flink JMS Table Connector
 
-This project contains a very small proof-of-concept implementation of a JMS table connector for [Apache Flink](https://flink.apache.org/). It shows how a custom table source and sink could be wired using Flink's `DynamicTableFactory` interfaces. The connector now uses the community maintained [`flink-connector-jms`](https://github.com/miwurster/flink-connector-jms) library instead of the Jakarta JMS API.
+This project contains a very small proof-of-concept implementation of a JMS table connector for [Apache Flink](https://flink.apache.org/). It shows how a custom table source and sink can be wired using Flink's `DynamicTableFactory` interfaces. The connector relies on the community maintained [`flink-connector-jms`](https://github.com/miwurster/flink-connector-jms) library and uses the **Jakarta JMS** API.
 
 The implementation is intentionally minimal and does not include a real JMS consumer or producer. It is meant as a starting point for integrating a JMS queue with Flink SQL. The factory registers under the identifier `jms` so you can define a table like:
 
@@ -30,3 +30,8 @@ uses the Maven Shade plugin so the resulting jar contains the JMS API and
 the RabbitMQ JMS client.  Copy the shaded jar into Flink's `usrlib`
 directory so the SQL client can load the connector together with the JMS
 dependencies.
+
+This project uses the **Jakarta JMS** API. Ensure that the JMS client
+implementation you provide is compiled for the `jakarta.jms` package.
+Mixing different JMS API versions (for example a client that still depends
+on `javax.jms`) will lead to class loading errors at runtime.

--- a/pom.xml
+++ b/pom.xml
@@ -22,16 +22,16 @@
       <artifactId>flink-connector-jms</artifactId>
       <version>1.0.0</version>
     </dependency>
-    <!-- JMS API and RabbitMQ JMS provider -->
+    <!-- Jakarta JMS API and RabbitMQ JMS provider -->
     <dependency>
-      <groupId>javax.jms</groupId>
-      <artifactId>javax.jms-api</artifactId>
-      <version>2.0.1</version>
+      <groupId>jakarta.jms</groupId>
+      <artifactId>jakarta.jms-api</artifactId>
+      <version>3.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.rabbitmq.jms</groupId>
       <artifactId>rabbitmq-jms</artifactId>
-      <version>1.15.2</version>
+      <version>3.0.0</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/example/jms/JmsSinkFunction.java
+++ b/src/main/java/com/example/jms/JmsSinkFunction.java
@@ -2,12 +2,12 @@ package com.example.jms;
 
 import java.util.Properties;
 
-import javax.jms.BytesMessage;
-import javax.jms.Connection;
-import javax.jms.ConnectionFactory;
-import javax.jms.Destination;
-import javax.jms.MessageProducer;
-import javax.jms.Session;
+import jakarta.jms.BytesMessage;
+import jakarta.jms.Connection;
+import jakarta.jms.ConnectionFactory;
+import jakarta.jms.Destination;
+import jakarta.jms.MessageProducer;
+import jakarta.jms.Session;
 import javax.naming.InitialContext;
 
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;

--- a/src/main/java/com/example/jms/JmsSourceFunction.java
+++ b/src/main/java/com/example/jms/JmsSourceFunction.java
@@ -2,13 +2,13 @@ package com.example.jms;
 
 import java.util.Properties;
 
-import javax.jms.BytesMessage;
-import javax.jms.Connection;
-import javax.jms.ConnectionFactory;
-import javax.jms.Destination;
-import javax.jms.Message;
-import javax.jms.MessageConsumer;
-import javax.jms.Session;
+import jakarta.jms.BytesMessage;
+import jakarta.jms.Connection;
+import jakarta.jms.ConnectionFactory;
+import jakarta.jms.Destination;
+import jakarta.jms.Message;
+import jakarta.jms.MessageConsumer;
+import jakarta.jms.Session;
 import javax.naming.Context;
 import javax.naming.InitialContext;
 


### PR DESCRIPTION
## Summary
- use `jakarta.jms` imports in JMS source and sink classes
- depend on `jakarta.jms-api` and newer RabbitMQ JMS provider
- mention Jakarta JMS usage in README

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6852d42486588321bcec7d4c70560439