### PR TITLE
Support queue.* properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,15 @@ CREATE TABLE ibm_mq (
   'jms.destination'              = 'MY.QUEUE',
   'jms.username'                = 'myuser',
   'jms.password'                = 'secret',
+  -- map logical queue names for the JNDI context
+  'queue.MY.QUEUE'             = 'MY.QUEUE',
   'format'                       = 'json'
 );
 ```
+
+Any options prefixed with `queue.` are added to the JNDI environment. This allows
+you to map logical names to JMS queues when using providers like Qpid that
+expect such entries (e.g. `queue.MY.QUEUE = MY.QUEUE`).
 
 The `jms.username` and `jms.password` options are optional and are passed to the
 underlying JMS `ConnectionFactory` when establishing the connection.

--- a/src/main/java/com/example/jms/JmsDynamicSink.java
+++ b/src/main/java/com/example/jms/JmsDynamicSink.java
@@ -22,6 +22,7 @@ public class JmsDynamicSink implements DynamicTableSink {
     private final String destination;
     private final String username;
     private final String password;
+    private final java.util.Map<String, String> jndiProperties;
 
     public JmsDynamicSink(
             EncodingFormat<SerializationSchema<RowData>> encodingFormat,
@@ -30,7 +31,8 @@ public class JmsDynamicSink implements DynamicTableSink {
             String providerUrl,
             String destination,
             String username,
-            String password) {
+            String password,
+            java.util.Map<String, String> jndiProperties) {
         this.encodingFormat = encodingFormat;
         this.consumedDataType = consumedDataType;
         this.contextFactory = contextFactory;
@@ -38,6 +40,7 @@ public class JmsDynamicSink implements DynamicTableSink {
         this.destination = destination;
         this.username = username;
         this.password = password;
+        this.jndiProperties = jndiProperties;
     }
 
     @Override
@@ -52,7 +55,13 @@ public class JmsDynamicSink implements DynamicTableSink {
 
         JmsSinkFunction sinkFunction =
                 new JmsSinkFunction(
-                        serializer, contextFactory, providerUrl, destination, username, password);
+                        serializer,
+                        contextFactory,
+                        providerUrl,
+                        destination,
+                        username,
+                        password,
+                        jndiProperties);
 
         return SinkFunctionProvider.of(sinkFunction);
     }
@@ -66,7 +75,8 @@ public class JmsDynamicSink implements DynamicTableSink {
                 providerUrl,
                 destination,
                 username,
-                password);
+                password,
+                jndiProperties);
     }
 
     @Override

--- a/src/main/java/com/example/jms/JmsDynamicSource.java
+++ b/src/main/java/com/example/jms/JmsDynamicSource.java
@@ -22,6 +22,7 @@ public class JmsDynamicSource implements ScanTableSource {
     private final String destination;
     private final String username;
     private final String password;
+    private final java.util.Map<String, String> jndiProperties;
 
     public JmsDynamicSource(
             DecodingFormat<DeserializationSchema<RowData>> decodingFormat,
@@ -30,7 +31,8 @@ public class JmsDynamicSource implements ScanTableSource {
             String providerUrl,
             String destination,
             String username,
-            String password) {
+            String password,
+            java.util.Map<String, String> jndiProperties) {
         this.decodingFormat = decodingFormat;
         this.producedDataType = producedDataType;
         this.contextFactory = contextFactory;
@@ -38,6 +40,7 @@ public class JmsDynamicSource implements ScanTableSource {
         this.destination = destination;
         this.username = username;
         this.password = password;
+        this.jndiProperties = jndiProperties;
     }
 
     @Override
@@ -53,7 +56,13 @@ public class JmsDynamicSource implements ScanTableSource {
 
         JmsSourceFunction sourceFunction =
                 new JmsSourceFunction(
-                        deserializer, contextFactory, providerUrl, destination, username, password);
+                        deserializer,
+                        contextFactory,
+                        providerUrl,
+                        destination,
+                        username,
+                        password,
+                        jndiProperties);
 
         return SourceFunctionProvider.of(sourceFunction, false);
     }
@@ -67,7 +76,8 @@ public class JmsDynamicSource implements ScanTableSource {
                 providerUrl,
                 destination,
                 username,
-                password);
+                password,
+                jndiProperties);
     }
 
     @Override

--- a/src/main/java/com/example/jms/JmsSinkFunction.java
+++ b/src/main/java/com/example/jms/JmsSinkFunction.java
@@ -27,6 +27,7 @@ public class JmsSinkFunction extends RichSinkFunction<RowData> {
     private final String destinationName;
     private final String username;
     private final String password;
+    private final java.util.Map<String, String> jndiProperties;
 
     private transient Connection connection;
     private transient Session session;
@@ -38,13 +39,15 @@ public class JmsSinkFunction extends RichSinkFunction<RowData> {
             String providerUrl,
             String destinationName,
             String username,
-            String password) {
+            String password,
+            java.util.Map<String, String> jndiProperties) {
         this.serializer = serializer;
         this.contextFactory = contextFactory;
         this.providerUrl = providerUrl;
         this.destinationName = destinationName;
         this.username = username;
         this.password = password;
+        this.jndiProperties = jndiProperties;
     }
 
     @Override
@@ -52,6 +55,11 @@ public class JmsSinkFunction extends RichSinkFunction<RowData> {
         Properties props = new Properties();
         props.setProperty(javax.naming.Context.INITIAL_CONTEXT_FACTORY, contextFactory);
         props.setProperty(javax.naming.Context.PROVIDER_URL, providerUrl);
+        if (jndiProperties != null) {
+            for (java.util.Map.Entry<String, String> e : jndiProperties.entrySet()) {
+                props.setProperty(e.getKey(), e.getValue());
+            }
+        }
         javax.naming.Context ctx = new InitialContext(props);
         ConnectionFactory factory = (ConnectionFactory) ctx.lookup("ConnectionFactory");
         Destination destination = (Destination) ctx.lookup(destinationName);

--- a/src/main/java/com/example/jms/JmsSourceFunction.java
+++ b/src/main/java/com/example/jms/JmsSourceFunction.java
@@ -31,6 +31,7 @@ public class JmsSourceFunction extends RichSourceFunction<RowData> {
     private final String destinationName;
     private final String username;
     private final String password;
+    private final java.util.Map<String, String> jndiProperties;
 
     private transient Connection connection;
     private transient Session session;
@@ -43,13 +44,15 @@ public class JmsSourceFunction extends RichSourceFunction<RowData> {
             String providerUrl,
             String destinationName,
             String username,
-            String password) {
+            String password,
+            java.util.Map<String, String> jndiProperties) {
         this.deserializer = deserializer;
         this.contextFactory = contextFactory;
         this.providerUrl = providerUrl;
         this.destinationName = destinationName;
         this.username = username;
         this.password = password;
+        this.jndiProperties = jndiProperties;
     }
 
     @Override
@@ -57,6 +60,11 @@ public class JmsSourceFunction extends RichSourceFunction<RowData> {
         Properties props = new Properties();
         props.setProperty(Context.INITIAL_CONTEXT_FACTORY, contextFactory);
         props.setProperty(Context.PROVIDER_URL, providerUrl);
+        if (jndiProperties != null) {
+            for (java.util.Map.Entry<String, String> e : jndiProperties.entrySet()) {
+                props.setProperty(e.getKey(), e.getValue());
+            }
+        }
         Context ctx = new InitialContext(props);
         ConnectionFactory factory = (ConnectionFactory) ctx.lookup("ConnectionFactory");
         Destination destination = (Destination) ctx.lookup(destinationName);

--- a/src/main/java/com/example/jms/JmsTableFactory.java
+++ b/src/main/java/com/example/jms/JmsTableFactory.java
@@ -1,6 +1,8 @@
 package com.example.jms;
 
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
@@ -50,6 +52,12 @@ public class JmsTableFactory implements DynamicTableSourceFactory, DynamicTableS
             .stringType()
             .noDefaultValue();
 
+    public static final String QUEUE_PREFIX = "queue.";
+    public static final ConfigOption<String> QUEUE = ConfigOptions
+            .key(QUEUE_PREFIX + "*")
+            .stringType()
+            .noDefaultValue();
+
     @Override
     public String factoryIdentifier() {
         return IDENTIFIER;
@@ -64,7 +72,7 @@ public class JmsTableFactory implements DynamicTableSourceFactory, DynamicTableS
     public Set<ConfigOption<?>> optionalOptions() {
         // Allow specifying a data format such as 'json'
         // so users can define 'format' in the WITH clause.
-        return Set.of(FactoryUtil.FORMAT, USERNAME, PASSWORD);
+        return Set.of(FactoryUtil.FORMAT, USERNAME, PASSWORD, QUEUE);
     }
 
     @Override
@@ -83,6 +91,10 @@ public class JmsTableFactory implements DynamicTableSourceFactory, DynamicTableS
         String destination = helper.getOptions().get(DESTINATION);
         String username = helper.getOptions().get(USERNAME);
         String password = helper.getOptions().get(PASSWORD);
+        Map<String, String> queueProps =
+                helper.getOptions().toMap().entrySet().stream()
+                        .filter(e -> e.getKey().startsWith(QUEUE_PREFIX))
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
         // validation
         helper.validate();
@@ -94,7 +106,8 @@ public class JmsTableFactory implements DynamicTableSourceFactory, DynamicTableS
                 providerUrl,
                 destination,
                 username,
-                password);
+                password,
+                queueProps);
     }
 
     @Override
@@ -113,6 +126,10 @@ public class JmsTableFactory implements DynamicTableSourceFactory, DynamicTableS
         String destination = helper.getOptions().get(DESTINATION);
         String username = helper.getOptions().get(USERNAME);
         String password = helper.getOptions().get(PASSWORD);
+        Map<String, String> queueProps =
+                helper.getOptions().toMap().entrySet().stream()
+                        .filter(e -> e.getKey().startsWith(QUEUE_PREFIX))
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
         // validation
         helper.validate();
@@ -124,6 +141,7 @@ public class JmsTableFactory implements DynamicTableSourceFactory, DynamicTableS
                 providerUrl,
                 destination,
                 username,
-                password);
+                password,
+                queueProps);
     }
 }


### PR DESCRIPTION
## Summary
- add `queue.*` config support in `JmsTableFactory`
- propagate queue properties to dynamic source/sink and to the runtime functions
- document usage of `queue.*` in README

## Testing
- `java -version`

------
https://chatgpt.com/codex/tasks/task_e_6852da4ddb208321995090b946a51bb6