### PR TITLE
Fix jms queue property extraction

### DIFF
--- a/src/main/java/com/example/jms/JmsTableFactory.java
+++ b/src/main/java/com/example/jms/JmsTableFactory.java
@@ -92,7 +92,7 @@ public class JmsTableFactory implements DynamicTableSourceFactory, DynamicTableS
         String username = helper.getOptions().get(USERNAME);
         String password = helper.getOptions().get(PASSWORD);
         Map<String, String> queueProps =
-                helper.getOptions().toMap().entrySet().stream()
+                context.getCatalogTable().getOptions().entrySet().stream()
                         .filter(e -> e.getKey().startsWith(QUEUE_PREFIX))
                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
@@ -127,7 +127,7 @@ public class JmsTableFactory implements DynamicTableSourceFactory, DynamicTableS
         String username = helper.getOptions().get(USERNAME);
         String password = helper.getOptions().get(PASSWORD);
         Map<String, String> queueProps =
-                helper.getOptions().toMap().entrySet().stream()
+                context.getCatalogTable().getOptions().entrySet().stream()
                         .filter(e -> e.getKey().startsWith(QUEUE_PREFIX))
                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 


### PR DESCRIPTION
## Summary
- use `Context.getCatalogTable().getOptions()` for JNDI properties

## Testing
- `mvn -q -e -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e03948c88321bbb4edc3808e9301