### PR TITLE
Allow queue prefix options

### DIFF
--- a/src/main/java/com/example/jms/JmsTableFactory.java
+++ b/src/main/java/com/example/jms/JmsTableFactory.java
@@ -96,8 +96,8 @@ public class JmsTableFactory implements DynamicTableSourceFactory, DynamicTableS
                         .filter(e -> e.getKey().startsWith(QUEUE_PREFIX))
                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
-        // validation
-        helper.validate();
+        // validation while ignoring queue.* options
+        helper.validateExcept(QUEUE_PREFIX + "*");
 
         return new JmsDynamicSource(
                 decodingFormat,
@@ -131,8 +131,8 @@ public class JmsTableFactory implements DynamicTableSourceFactory, DynamicTableS
                         .filter(e -> e.getKey().startsWith(QUEUE_PREFIX))
                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
-        // validation
-        helper.validate();
+        // validation while ignoring queue.* options
+        helper.validateExcept(QUEUE_PREFIX + "*");
 
         return new JmsDynamicSink(
                 encodingFormat,


### PR DESCRIPTION
## Summary
- ignore `queue.*` options during validation

## Testing
- `pre-commit` *(fails: `pre-commit` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6852e42d5adc8321a029bc7ec28b2984