### PR TITLE
Add default queue mapping in JmsTableFactory

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ CREATE TABLE ibm_mq (
   'jms.destination'              = 'MY.QUEUE',
   'jms.username'                = 'myuser',
   'jms.password'                = 'secret',
-  -- map logical queue names for the JNDI context
+  -- map logical queue names for the JNDI context (optional)
   'queue.MY.QUEUE'             = 'MY.QUEUE',
   'format'                       = 'json'
 );
@@ -23,7 +23,9 @@ CREATE TABLE ibm_mq (
 
 Any options prefixed with `queue.` are added to the JNDI environment. This allows
 you to map logical names to JMS queues when using providers like Qpid that
-expect such entries (e.g. `queue.MY.QUEUE = MY.QUEUE`).
+expect such entries (e.g. `queue.MY.QUEUE = MY.QUEUE`). If `jms.destination`
+is set and no corresponding `queue.<dest>` option is supplied, the connector will
+automatically add `'queue.<dest>' = <dest>`.
 
 The `jms.username` and `jms.password` options are optional and are passed to the
 underlying JMS `ConnectionFactory` when establishing the connection.

--- a/src/main/java/com/example/jms/JmsTableFactory.java
+++ b/src/main/java/com/example/jms/JmsTableFactory.java
@@ -96,6 +96,10 @@ public class JmsTableFactory implements DynamicTableSourceFactory, DynamicTableS
                         .filter(e -> e.getKey().startsWith(QUEUE_PREFIX))
                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
+        if (!queueProps.containsKey(QUEUE_PREFIX + destination)) {
+            queueProps.put(QUEUE_PREFIX + destination, destination);
+        }
+
         // validation while ignoring queue.* options
         helper.validateExcept(QUEUE_PREFIX + "*");
 
@@ -130,6 +134,10 @@ public class JmsTableFactory implements DynamicTableSourceFactory, DynamicTableS
                 context.getCatalogTable().getOptions().entrySet().stream()
                         .filter(e -> e.getKey().startsWith(QUEUE_PREFIX))
                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        if (!queueProps.containsKey(QUEUE_PREFIX + destination)) {
+            queueProps.put(QUEUE_PREFIX + destination, destination);
+        }
 
         // validation while ignoring queue.* options
         helper.validateExcept(QUEUE_PREFIX + "*");


### PR DESCRIPTION
## Summary
- map destination automatically if no matching `queue.*` option is present
- mention optional queue mapping in README

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852eb2e08908321844c8fe5c9e78ba7