### PR TITLE
Initialize deserializer in JMS source

### DIFF
--- a/src/main/java/com/example/jms/JmsSourceFunction.java
+++ b/src/main/java/com/example/jms/JmsSourceFunction.java
@@ -79,6 +79,9 @@ public class JmsSourceFunction extends RichSourceFunction<RowData> {
         session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
         consumer = session.createConsumer(destination);
         connection.start();
+
+        // initialize the deserializer so it is ready to deserialize incoming messages
+        deserializer.open(null);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- ensure `JmsSourceFunction` initializes its deserializer in `open()`

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68531bd3e8388321b91e041e20dceb7f