### PR TITLE
Support IBM MQ without JNDI

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,25 @@ CREATE TABLE ibm_mq (
 );
 ```
 
+If the IBM MQ JNDI libraries are not available you can configure the MQ
+connection directly without using `jms.initial-context-factory` and
+`jms.provider-url`:
+
+```sql
+CREATE TABLE ibm_mq (
+  field1 STRING,
+  field2 INT
+) WITH (
+  'connector'       = 'jms',
+  'jms.destination' = 'MY.QUEUE',
+  'jms.mq-host'     = 'mq.example.com',
+  'jms.mq-port'     = '1414',
+  'jms.mq-queue-manager' = 'QMGR',
+  'jms.mq-channel' = 'DEV.APP.SVRCONN',
+  'format'         = 'json'
+);
+```
+
 Any options prefixed with `queue.` are added to the JNDI environment. This allows
 you to map logical names to JMS queues when using providers like Qpid that
 expect such entries (e.g. `queue.MY.QUEUE = MY.QUEUE`). If `jms.destination`

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,13 @@
       <version>${qpid-jms.version}</version>
     </dependency>
 
+    <!-- IBM MQ JMS client -->
+    <dependency>
+      <groupId>com.ibm.mq</groupId>
+      <artifactId>com.ibm.mq.allclient</artifactId>
+      <version>9.3.5.0</version>
+    </dependency>
+
     <!-- Jakarta JMS API (provided by Flink / container at runtime) -->
     <dependency>
       <groupId>jakarta.jms</groupId>
@@ -119,6 +126,7 @@
                   <include>javax.jms:javax.jms-api</include>
                   <include>com.rabbitmq.jms:rabbitmq-jms</include>
                   <include>com.rabbitmq:amqp-client</include>
+                  <include>com.ibm.mq:com.ibm.mq.allclient</include>
                   <include>io.netty:netty-*</include>
                 </includes>
               </artifactSet>

--- a/src/main/java/com/example/jms/JmsDynamicSink.java
+++ b/src/main/java/com/example/jms/JmsDynamicSink.java
@@ -23,6 +23,10 @@ public class JmsDynamicSink implements DynamicTableSink {
     private final String username;
     private final String password;
     private final java.util.Map<String, String> jndiProperties;
+    private final String mqHost;
+    private final Integer mqPort;
+    private final String mqQueueManager;
+    private final String mqChannel;
 
     public JmsDynamicSink(
             EncodingFormat<SerializationSchema<RowData>> encodingFormat,
@@ -32,7 +36,11 @@ public class JmsDynamicSink implements DynamicTableSink {
             String destination,
             String username,
             String password,
-            java.util.Map<String, String> jndiProperties) {
+            java.util.Map<String, String> jndiProperties,
+            String mqHost,
+            Integer mqPort,
+            String mqQueueManager,
+            String mqChannel) {
         this.encodingFormat = encodingFormat;
         this.consumedDataType = consumedDataType;
         this.contextFactory = contextFactory;
@@ -41,6 +49,10 @@ public class JmsDynamicSink implements DynamicTableSink {
         this.username = username;
         this.password = password;
         this.jndiProperties = jndiProperties;
+        this.mqHost = mqHost;
+        this.mqPort = mqPort;
+        this.mqQueueManager = mqQueueManager;
+        this.mqChannel = mqChannel;
     }
 
     @Override
@@ -61,7 +73,11 @@ public class JmsDynamicSink implements DynamicTableSink {
                         destination,
                         username,
                         password,
-                        jndiProperties);
+                        jndiProperties,
+                        mqHost,
+                        mqPort,
+                        mqQueueManager,
+                        mqChannel);
 
         return SinkFunctionProvider.of(sinkFunction);
     }
@@ -76,7 +92,11 @@ public class JmsDynamicSink implements DynamicTableSink {
                 destination,
                 username,
                 password,
-                jndiProperties);
+                jndiProperties,
+                mqHost,
+                mqPort,
+                mqQueueManager,
+                mqChannel);
     }
 
     @Override

--- a/src/main/java/com/example/jms/JmsDynamicSource.java
+++ b/src/main/java/com/example/jms/JmsDynamicSource.java
@@ -23,6 +23,10 @@ public class JmsDynamicSource implements ScanTableSource {
     private final String username;
     private final String password;
     private final java.util.Map<String, String> jndiProperties;
+    private final String mqHost;
+    private final Integer mqPort;
+    private final String mqQueueManager;
+    private final String mqChannel;
 
     public JmsDynamicSource(
             DecodingFormat<DeserializationSchema<RowData>> decodingFormat,
@@ -32,7 +36,11 @@ public class JmsDynamicSource implements ScanTableSource {
             String destination,
             String username,
             String password,
-            java.util.Map<String, String> jndiProperties) {
+            java.util.Map<String, String> jndiProperties,
+            String mqHost,
+            Integer mqPort,
+            String mqQueueManager,
+            String mqChannel) {
         this.decodingFormat = decodingFormat;
         this.producedDataType = producedDataType;
         this.contextFactory = contextFactory;
@@ -41,6 +49,10 @@ public class JmsDynamicSource implements ScanTableSource {
         this.username = username;
         this.password = password;
         this.jndiProperties = jndiProperties;
+        this.mqHost = mqHost;
+        this.mqPort = mqPort;
+        this.mqQueueManager = mqQueueManager;
+        this.mqChannel = mqChannel;
     }
 
     @Override
@@ -62,7 +74,11 @@ public class JmsDynamicSource implements ScanTableSource {
                         destination,
                         username,
                         password,
-                        jndiProperties);
+                        jndiProperties,
+                        mqHost,
+                        mqPort,
+                        mqQueueManager,
+                        mqChannel);
 
         return SourceFunctionProvider.of(sourceFunction, false);
     }
@@ -77,7 +93,11 @@ public class JmsDynamicSource implements ScanTableSource {
                 destination,
                 username,
                 password,
-                jndiProperties);
+                jndiProperties,
+                mqHost,
+                mqPort,
+                mqQueueManager,
+                mqChannel);
     }
 
     @Override

--- a/src/main/java/com/example/jms/JmsSourceFunction.java
+++ b/src/main/java/com/example/jms/JmsSourceFunction.java
@@ -14,6 +14,10 @@ import jakarta.jms.Session;
 import javax.naming.Context;
 import javax.naming.InitialContext;
 
+// IBM MQ specific classes used when bypassing JNDI
+import com.ibm.mq.jms.MQConnectionFactory;
+import com.ibm.msg.client.wmq.WMQConstants;
+
 import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
@@ -34,6 +38,10 @@ public class JmsSourceFunction extends RichSourceFunction<RowData> {
     private final String username;
     private final String password;
     private final java.util.Map<String, String> jndiProperties;
+    private final String mqHost;
+    private final Integer mqPort;
+    private final String mqQueueManager;
+    private final String mqChannel;
 
     private transient Connection connection;
     private transient Session session;
@@ -47,7 +55,11 @@ public class JmsSourceFunction extends RichSourceFunction<RowData> {
             String destinationName,
             String username,
             String password,
-            java.util.Map<String, String> jndiProperties) {
+            java.util.Map<String, String> jndiProperties,
+            String mqHost,
+            Integer mqPort,
+            String mqQueueManager,
+            String mqChannel) {
         this.deserializer = deserializer;
         this.contextFactory = contextFactory;
         this.providerUrl = providerUrl;
@@ -55,29 +67,60 @@ public class JmsSourceFunction extends RichSourceFunction<RowData> {
         this.username = username;
         this.password = password;
         this.jndiProperties = jndiProperties;
+        this.mqHost = mqHost;
+        this.mqPort = mqPort;
+        this.mqQueueManager = mqQueueManager;
+        this.mqChannel = mqChannel;
     }
 
     @Override
     public void open(Configuration parameters) throws Exception {
-        Properties props = new Properties();
-        props.setProperty(Context.INITIAL_CONTEXT_FACTORY, contextFactory);
-        props.setProperty(Context.PROVIDER_URL, providerUrl);
-        if (jndiProperties != null) {
-            for (java.util.Map.Entry<String, String> e : jndiProperties.entrySet()) {
-                props.setProperty(e.getKey(), e.getValue());
+        if (contextFactory != null && providerUrl != null) {
+            Properties props = new Properties();
+            props.setProperty(Context.INITIAL_CONTEXT_FACTORY, contextFactory);
+            props.setProperty(Context.PROVIDER_URL, providerUrl);
+            if (jndiProperties != null) {
+                for (java.util.Map.Entry<String, String> e : jndiProperties.entrySet()) {
+                    props.setProperty(e.getKey(), e.getValue());
+                }
             }
-        }
-        Context ctx = new InitialContext(props);
-        ConnectionFactory factory = (ConnectionFactory) ctx.lookup("ConnectionFactory");
-        Destination destination = (Destination) ctx.lookup(destinationName);
+            Context ctx = new InitialContext(props);
+            ConnectionFactory factory = (ConnectionFactory) ctx.lookup("ConnectionFactory");
+            Destination destination = (Destination) ctx.lookup(destinationName);
 
-        if (username != null) {
-            connection = factory.createConnection(username, password);
+            if (username != null) {
+                connection = factory.createConnection(username, password);
+            } else {
+                connection = factory.createConnection();
+            }
+            session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+            consumer = session.createConsumer(destination);
         } else {
-            connection = factory.createConnection();
+            // programmatic IBM MQ configuration without JNDI
+            com.ibm.mq.jms.MQConnectionFactory factory = new com.ibm.mq.jms.MQConnectionFactory();
+            if (mqHost != null) {
+                factory.setHostName(mqHost);
+            }
+            if (mqPort != null) {
+                factory.setPort(mqPort);
+            }
+            if (mqQueueManager != null) {
+                factory.setQueueManager(mqQueueManager);
+            }
+            if (mqChannel != null) {
+                factory.setChannel(mqChannel);
+            }
+            factory.setTransportType(com.ibm.msg.client.wmq.WMQConstants.WMQ_CM_CLIENT);
+
+            if (username != null) {
+                connection = factory.createConnection(username, password);
+            } else {
+                connection = factory.createConnection();
+            }
+            session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+            Destination destination = session.createQueue(destinationName);
+            consumer = session.createConsumer(destination);
         }
-        session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
-        consumer = session.createConsumer(destination);
         connection.start();
 
         // initialize the deserializer so it is ready to deserialize incoming messages


### PR DESCRIPTION
## Summary
- allow direct IBM MQ configuration by adding options `jms.mq-*`
- implement MQ connection logic in source and sink when JNDI is not provided
- pass new options through dynamic table source/sink
- document direct connection usage in README
- bundle IBM MQ client via Maven

## Testing
- `mvn -q -DskipTests -o package` *(fails: Plugin resolution requires network access)*

------
https://chatgpt.com/codex/tasks/task_e_68535f86bc288321b6042375ea077202