### PR TITLE
Fix JMS artifact and table factory options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,10 +46,10 @@
       <version>${qpid-jms.version}</version>
     </dependency>
 
-    <!-- IBM MQ JMS client -->
+    <!-- IBM MQ JMS client built for Jakarta API -->
     <dependency>
       <groupId>com.ibm.mq</groupId>
-      <artifactId>com.ibm.mq.allclient</artifactId>
+      <artifactId>com.ibm.mq.jakarta.client</artifactId>
       <version>9.3.5.0</version>
     </dependency>
 

--- a/src/main/java/com/example/jms/JmsTableFactory.java
+++ b/src/main/java/com/example/jms/JmsTableFactory.java
@@ -129,10 +129,6 @@ public class JmsTableFactory implements DynamicTableSourceFactory, DynamicTableS
         Integer mqPort = helper.getOptions().get(MQ_PORT);
         String mqQueueManager = helper.getOptions().get(MQ_QUEUE_MANAGER);
         String mqChannel = helper.getOptions().get(MQ_CHANNEL);
-        String mqHost = helper.getOptions().get(MQ_HOST);
-        Integer mqPort = helper.getOptions().get(MQ_PORT);
-        String mqQueueManager = helper.getOptions().get(MQ_QUEUE_MANAGER);
-        String mqChannel = helper.getOptions().get(MQ_CHANNEL);
         Map<String, String> queueProps =
                 context.getCatalogTable().getOptions().entrySet().stream()
                         .filter(e -> e.getKey().startsWith(QUEUE_PREFIX))
@@ -176,6 +172,10 @@ public class JmsTableFactory implements DynamicTableSourceFactory, DynamicTableS
         String destination = helper.getOptions().get(DESTINATION);
         String username = helper.getOptions().get(USERNAME);
         String password = helper.getOptions().get(PASSWORD);
+        String mqHost = helper.getOptions().get(MQ_HOST);
+        Integer mqPort = helper.getOptions().get(MQ_PORT);
+        String mqQueueManager = helper.getOptions().get(MQ_QUEUE_MANAGER);
+        String mqChannel = helper.getOptions().get(MQ_CHANNEL);
         Map<String, String> queueProps =
                 context.getCatalogTable().getOptions().entrySet().stream()
                         .filter(e -> e.getKey().startsWith(QUEUE_PREFIX))


### PR DESCRIPTION
## Summary
- switch IBM MQ dependency to the Jakarta JMS variant
- fix duplicated option parsing in `JmsTableFactory`
- pass MQ configuration to the table sink

## Testing
- `mvn -q -DskipTests package` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_6853654ce67c8321b12c51905c1f7980