### PR TITLE
Fix IBM MQ package names

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ CREATE TABLE ibm_mq (
   field2 INT
 ) WITH (
   'connector'                    = 'jms',
-  'jms.initial-context-factory'  = 'com.ibm.mq.jms.context.WMQInitialContextFactory',
+  'jms.initial-context-factory'  = 'com.ibm.mq.jakarta.jms.context.WMQInitialContextFactory',
   'jms.provider-url'             = 'mq://host:1414/QMGR',
   'jms.destination'              = 'MY.QUEUE',
   'jms.username'                = 'myuser',

--- a/src/main/java/com/example/jms/JmsSinkFunction.java
+++ b/src/main/java/com/example/jms/JmsSinkFunction.java
@@ -11,8 +11,8 @@ import jakarta.jms.Session;
 import javax.naming.InitialContext;
 
 // IBM MQ classes used when bypassing JNDI
-import com.ibm.mq.jms.MQConnectionFactory;
-import com.ibm.msg.client.wmq.WMQConstants;
+import com.ibm.mq.jakarta.jms.MQConnectionFactory;
+import com.ibm.msg.client.jakarta.wmq.WMQConstants;
 
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;

--- a/src/main/java/com/example/jms/JmsSourceFunction.java
+++ b/src/main/java/com/example/jms/JmsSourceFunction.java
@@ -15,8 +15,8 @@ import javax.naming.Context;
 import javax.naming.InitialContext;
 
 // IBM MQ specific classes used when bypassing JNDI
-import com.ibm.mq.jms.MQConnectionFactory;
-import com.ibm.msg.client.wmq.WMQConstants;
+import com.ibm.mq.jakarta.jms.MQConnectionFactory;
+import com.ibm.msg.client.jakarta.wmq.WMQConstants;
 
 import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext;
@@ -97,7 +97,7 @@ public class JmsSourceFunction extends RichSourceFunction<RowData> {
             consumer = session.createConsumer(destination);
         } else {
             // programmatic IBM MQ configuration without JNDI
-            com.ibm.mq.jms.MQConnectionFactory factory = new com.ibm.mq.jms.MQConnectionFactory();
+            com.ibm.mq.jakarta.jms.MQConnectionFactory factory = new com.ibm.mq.jakarta.jms.MQConnectionFactory();
             if (mqHost != null) {
                 factory.setHostName(mqHost);
             }
@@ -110,7 +110,7 @@ public class JmsSourceFunction extends RichSourceFunction<RowData> {
             if (mqChannel != null) {
                 factory.setChannel(mqChannel);
             }
-            factory.setTransportType(com.ibm.msg.client.wmq.WMQConstants.WMQ_CM_CLIENT);
+            factory.setTransportType(com.ibm.msg.client.jakarta.wmq.WMQConstants.WMQ_CM_CLIENT);
 
             if (username != null) {
                 connection = factory.createConnection(username, password);


### PR DESCRIPTION
## Summary
- update IBM MQ imports for Jakarta packages
- tweak IBM MQ context factory in README

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6853679319b8832190719c6b89a14089