### PR TITLE
Add XML deserializer converting to JSON

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,20 @@
       <version>0.33.9</version>
     </dependency>
 
+    <!-- Flink JSON format for RowData -->
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-json</artifactId>
+      <version>${flink.version}</version>
+    </dependency>
+
+    <!-- org.json for XML to JSON conversion -->
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20231013</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/src/main/java/com/example/jms/format/XmlJsonFormatFactory.java
+++ b/src/main/java/com/example/jms/format/XmlJsonFormatFactory.java
@@ -1,0 +1,55 @@
+package com.example.jms.format;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.format.DecodingFormat;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.DeserializationFormatFactory;
+import org.apache.flink.table.factories.DynamicTableFactory;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+
+/**
+ * Factory to create a decoding format that converts XML payloads to JSON.
+ */
+public class XmlJsonFormatFactory implements DeserializationFormatFactory {
+
+    public static final String IDENTIFIER = "xml-json";
+
+    @Override
+    public DecodingFormat<DeserializationSchema<RowData>> createDecodingFormat(
+            DynamicTableFactory.Context context, org.apache.flink.configuration.ReadableConfig formatOptions) {
+        return new DecodingFormat<DeserializationSchema<RowData>>() {
+            @Override
+            public DeserializationSchema<RowData> createRuntimeDecoder(DynamicTableSource.Context sourceContext, DataType producedDataType) {
+                RowType rowType = (RowType) producedDataType.getLogicalType();
+                return new XmlToJsonDeserializationSchema(rowType);
+            }
+
+            @Override
+            public ChangelogMode getChangelogMode() {
+                return ChangelogMode.insertOnly();
+            }
+        };
+    }
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        return Collections.emptySet();
+    }
+}

--- a/src/main/java/com/example/jms/format/XmlToJsonDeserializationSchema.java
+++ b/src/main/java/com/example/jms/format/XmlToJsonDeserializationSchema.java
@@ -1,0 +1,59 @@
+package com.example.jms.format;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.formats.json.JsonRowDataDeserializationSchema;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.json.JSONObject;
+import org.json.XML;
+
+/**
+ * DeserializationSchema that converts XML payloads to JSON and then delegates
+ * to Flink's JsonRowDataDeserializationSchema.
+ */
+public class XmlToJsonDeserializationSchema implements DeserializationSchema<RowData> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final JsonRowDataDeserializationSchema jsonDeserializer;
+
+    public XmlToJsonDeserializationSchema(RowType rowType) {
+        this.jsonDeserializer = new JsonRowDataDeserializationSchema(
+                rowType,
+                InternalTypeInfo.of(rowType),
+                false,
+                false);
+    }
+
+    @Override
+    public void open(InitializationContext context) throws Exception {
+        jsonDeserializer.open(context);
+    }
+
+    @Override
+    public RowData deserialize(byte[] message) throws IOException {
+        try {
+            String xml = new String(message, StandardCharsets.UTF_8);
+            JSONObject jsonObject = XML.toJSONObject(xml);
+            byte[] jsonBytes = jsonObject.toString().getBytes(StandardCharsets.UTF_8);
+            return jsonDeserializer.deserialize(jsonBytes);
+        } catch (Exception e) {
+            throw new IOException("Failed to convert XML to JSON", e);
+        }
+    }
+
+    @Override
+    public boolean isEndOfStream(RowData nextElement) {
+        return false;
+    }
+
+    @Override
+    public TypeInformation<RowData> getProducedType() {
+        return jsonDeserializer.getProducedType();
+    }
+}

--- a/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -1,1 +1,2 @@
 com.example.jms.JmsTableFactory
+com.example.jms.format.XmlJsonFormatFactory


### PR DESCRIPTION
## Summary
- add XmlToJsonDeserializationSchema that converts XML payloads to JSON
- create XmlJsonFormatFactory to use the new schema in table definitions
- register the new factory as a Flink `Factory`
- include JSON and org.json dependencies

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact maven-resources-plugin due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685823d6e610832189af72915b444a92