### PR TITLE
Add option to bypass exactly-once for JMS sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ CREATE TABLE ibm_mq (
   'jms.destination'              = 'MY.QUEUE',
   'jms.username'                = 'myuser',
   'jms.password'                = 'secret',
+  -- disable exactly once semantics if messages should be committed
+  -- without waiting for a Flink checkpoint
+  'jms.exactly-once'            = 'false',
   -- map logical queue names for the JNDI context (optional)
   'queue.MY.QUEUE'             = 'MY.QUEUE',
   'format'                       = 'json'
@@ -34,6 +37,8 @@ CREATE TABLE ibm_mq (
   'jms.mq-port'     = '1414',
   'jms.mq-queue-manager' = 'QMGR',
   'jms.mq-channel' = 'DEV.APP.SVRCONN',
+  -- disable exactly-once semantics if desired
+  'jms.exactly-once' = 'false',
   'format'         = 'json'
 );
 ```
@@ -43,6 +48,9 @@ you to map logical names to JMS queues when using providers like Qpid that
 expect such entries (e.g. `queue.MY.QUEUE = MY.QUEUE`). If `jms.destination`
 is set and no corresponding `queue.<dest>` option is supplied, the connector will
 automatically add `'queue.<dest>' = <dest>`.
+
+Set `'jms.exactly-once' = 'false'` if you want the sink to commit each message
+immediately without waiting for a Flink checkpoint.
 
 The `jms.username` and `jms.password` options are optional and are passed to the
 underlying JMS `ConnectionFactory` when establishing the connection.

--- a/src/main/java/com/example/jms/JmsTableFactory.java
+++ b/src/main/java/com/example/jms/JmsTableFactory.java
@@ -73,6 +73,11 @@ public class JmsTableFactory implements DynamicTableSourceFactory, DynamicTableS
             .stringType()
             .noDefaultValue();
 
+    public static final ConfigOption<Boolean> EXACTLY_ONCE = ConfigOptions
+            .key("jms.exactly-once")
+            .booleanType()
+            .defaultValue(true);
+
     public static final String QUEUE_PREFIX = "queue.";
     public static final ConfigOption<String> QUEUE = ConfigOptions
             .key(QUEUE_PREFIX + "*")
@@ -106,7 +111,8 @@ public class JmsTableFactory implements DynamicTableSourceFactory, DynamicTableS
                 MQ_HOST,
                 MQ_PORT,
                 MQ_QUEUE_MANAGER,
-                MQ_CHANNEL);
+                MQ_CHANNEL,
+                EXACTLY_ONCE);
     }
 
     @Override
@@ -129,6 +135,7 @@ public class JmsTableFactory implements DynamicTableSourceFactory, DynamicTableS
         Integer mqPort = helper.getOptions().get(MQ_PORT);
         String mqQueueManager = helper.getOptions().get(MQ_QUEUE_MANAGER);
         String mqChannel = helper.getOptions().get(MQ_CHANNEL);
+        boolean exactlyOnce = helper.getOptions().get(EXACTLY_ONCE);
         Map<String, String> queueProps =
                 context.getCatalogTable().getOptions().entrySet().stream()
                         .filter(e -> e.getKey().startsWith(QUEUE_PREFIX))
@@ -176,6 +183,7 @@ public class JmsTableFactory implements DynamicTableSourceFactory, DynamicTableS
         Integer mqPort = helper.getOptions().get(MQ_PORT);
         String mqQueueManager = helper.getOptions().get(MQ_QUEUE_MANAGER);
         String mqChannel = helper.getOptions().get(MQ_CHANNEL);
+        boolean exactlyOnce = helper.getOptions().get(EXACTLY_ONCE);
         Map<String, String> queueProps =
                 context.getCatalogTable().getOptions().entrySet().stream()
                         .filter(e -> e.getKey().startsWith(QUEUE_PREFIX))
@@ -200,6 +208,7 @@ public class JmsTableFactory implements DynamicTableSourceFactory, DynamicTableS
                 mqHost,
                 mqPort,
                 mqQueueManager,
-                mqChannel);
+                mqChannel,
+                exactlyOnce);
     }
 }


### PR DESCRIPTION
## Summary
- allow disabling checkpoint-based commits via new `jms.exactly-once` table option
- if disabled, use `JmsSinkFunction` to commit messages immediately
- document the new option
- fix missing variable when creating the sink

## Testing
- `mvn -q -DskipTests package` *(fails: mvn command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860fbbb74448321a2dda3d34f57486d