### PR TITLE
Fix DataInputView imports

### DIFF
--- a/src/main/java/com/example/jms/JmsExactlyOnceSinkFunction.java
+++ b/src/main/java/com/example/jms/JmsExactlyOnceSinkFunction.java
@@ -13,6 +13,9 @@ import com.ibm.msg.client.jakarta.wmq.WMQConstants;
 
 import java.util.Properties;
 
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.functions.sink.TwoPhaseCommitSinkFunction;
@@ -99,16 +102,15 @@ public class JmsExactlyOnceSinkFunction extends TwoPhaseCommitSinkFunction<RowDa
         }
 
         @Override
-        public void serialize(JmsTransaction record, java.io.DataOutputView target) {}
+        public void serialize(JmsTransaction record, DataOutputView target) {}
 
         @Override
-        public JmsTransaction deserialize(java.io.DataInputView source) {
+        public JmsTransaction deserialize(DataInputView source) {
             return new JmsTransaction();
         }
 
         @Override
-        public void copy(
-                java.io.DataInputView source, java.io.DataOutputView target) {}
+        public void copy(DataInputView source, DataOutputView target) {}
 
         @Override
         public boolean canEqual(Object obj) {


### PR DESCRIPTION
## Summary
- fix broken imports in `JmsExactlyOnceSinkFunction`

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686b7ae41e6c8321b0bc0b5d4b03482e