### PR TITLE
Implement missing methods in JmsTransactionSerializer

### DIFF
--- a/src/main/java/com/example/jms/JmsExactlyOnceSinkFunction.java
+++ b/src/main/java/com/example/jms/JmsExactlyOnceSinkFunction.java
@@ -110,11 +110,31 @@ public class JmsExactlyOnceSinkFunction extends TwoPhaseCommitSinkFunction<RowDa
         }
 
         @Override
+        public JmsTransaction deserialize(JmsTransaction reuse, DataInputView source) {
+            return new JmsTransaction();
+        }
+
+        @Override
         public void copy(DataInputView source, DataOutputView target) {}
 
         @Override
         public boolean canEqual(Object obj) {
             return obj instanceof JmsTransactionSerializer;
+        }
+
+        @Override
+        public org.apache.flink.api.common.typeutils.TypeSerializerSnapshot<JmsTransaction>
+                snapshotConfiguration() {
+            return new JmsTransactionSerializerSnapshot();
+        }
+    }
+
+    /** Serializer snapshot for compatibility. */
+    public static final class JmsTransactionSerializerSnapshot
+            extends org.apache.flink.api.common.typeutils.SimpleTypeSerializerSnapshot<JmsTransaction> {
+
+        public JmsTransactionSerializerSnapshot() {
+            super(JmsTransactionSerializer::new);
         }
     }
 


### PR DESCRIPTION
## Summary
- implement `deserialize(JmsTransaction, DataInputView)` and serializer snapshot for `JmsTransactionSerializer`

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact maven-resources-plugin due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686b7e66e204832188e5cea9e0c6e5d9