### PR TITLE
Fix invalid override in sink serializer

### DIFF
--- a/src/main/java/com/example/jms/JmsExactlyOnceSinkFunction.java
+++ b/src/main/java/com/example/jms/JmsExactlyOnceSinkFunction.java
@@ -118,11 +118,6 @@ public class JmsExactlyOnceSinkFunction extends TwoPhaseCommitSinkFunction<RowDa
         public void copy(DataInputView source, DataOutputView target) {}
 
         @Override
-        public boolean canEqual(Object obj) {
-            return obj instanceof JmsTransactionSerializer;
-        }
-
-        @Override
         public org.apache.flink.api.common.typeutils.TypeSerializerSnapshot<JmsTransaction>
                 snapshotConfiguration() {
             return new JmsTransactionSerializerSnapshot();


### PR DESCRIPTION
## Summary
- remove `canEqual` implementation from `JmsTransactionSerializer`

The method was marked with `@Override` but no such method exists in `TypeSerializerSingleton`, causing a compilation failure.

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686b80124e3483218f0c42e6d9e2ec46