### PR TITLE
Enable async put for IBM MQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ CREATE TABLE ibm_mq (
   -- disable exactly once semantics if messages should be committed
   -- without waiting for a Flink checkpoint
   'jms.exactly-once'            = 'false',
+  -- enable asynchronous puts for IBM MQ
+  'jms.async.put'              = 'true',
   -- map logical queue names for the JNDI context (optional)
   'queue.MY.QUEUE'             = 'MY.QUEUE',
   'format'                       = 'json'
@@ -39,6 +41,8 @@ CREATE TABLE ibm_mq (
   'jms.mq-channel' = 'DEV.APP.SVRCONN',
   -- disable exactly-once semantics if desired
   'jms.exactly-once' = 'false',
+  -- enable asynchronous puts for IBM MQ
+  'jms.async.put'  = 'true',
   'format'         = 'json'
 );
 ```
@@ -51,6 +55,8 @@ automatically add `'queue.<dest>' = <dest>`.
 
 Set `'jms.exactly-once' = 'false'` if you want the sink to commit each message
 immediately without waiting for a Flink checkpoint.
+Set `'jms.async.put' = 'true'` to enable IBM MQ's asynchronous put mode so that
+`send()` and `commit()` return quickly.
 
 The `jms.username` and `jms.password` options are optional and are passed to the
 underlying JMS `ConnectionFactory` when establishing the connection.

--- a/src/main/java/com/example/jms/JmsDynamicSink.java
+++ b/src/main/java/com/example/jms/JmsDynamicSink.java
@@ -29,6 +29,7 @@ public class JmsDynamicSink implements DynamicTableSink {
     private final String mqQueueManager;
     private final String mqChannel;
     private final boolean exactlyOnce;
+    private final boolean asyncPut;
 
     public JmsDynamicSink(
             EncodingFormat<SerializationSchema<RowData>> encodingFormat,
@@ -43,7 +44,8 @@ public class JmsDynamicSink implements DynamicTableSink {
             Integer mqPort,
             String mqQueueManager,
             String mqChannel,
-            boolean exactlyOnce) {
+            boolean exactlyOnce,
+            boolean asyncPut) {
         this.encodingFormat = encodingFormat;
         this.consumedDataType = consumedDataType;
         this.contextFactory = contextFactory;
@@ -57,6 +59,7 @@ public class JmsDynamicSink implements DynamicTableSink {
         this.mqQueueManager = mqQueueManager;
         this.mqChannel = mqChannel;
         this.exactlyOnce = exactlyOnce;
+        this.asyncPut = asyncPut;
     }
 
     @Override
@@ -82,7 +85,8 @@ public class JmsDynamicSink implements DynamicTableSink {
                             mqHost,
                             mqPort,
                             mqQueueManager,
-                            mqChannel);
+                            mqChannel,
+                            asyncPut);
             return SinkFunctionProvider.of(sinkFunction);
         } else {
             JmsSinkFunction sinkFunction =
@@ -97,7 +101,8 @@ public class JmsDynamicSink implements DynamicTableSink {
                             mqHost,
                             mqPort,
                             mqQueueManager,
-                            mqChannel);
+                            mqChannel,
+                            asyncPut);
             return SinkFunctionProvider.of(sinkFunction);
         }
     }
@@ -117,7 +122,8 @@ public class JmsDynamicSink implements DynamicTableSink {
                 mqPort,
                 mqQueueManager,
                 mqChannel,
-                exactlyOnce);
+                exactlyOnce,
+                asyncPut);
     }
 
     @Override

--- a/src/main/java/com/example/jms/JmsTableFactory.java
+++ b/src/main/java/com/example/jms/JmsTableFactory.java
@@ -78,6 +78,11 @@ public class JmsTableFactory implements DynamicTableSourceFactory, DynamicTableS
             .booleanType()
             .defaultValue(true);
 
+    public static final ConfigOption<Boolean> ASYNC_PUT = ConfigOptions
+            .key("jms.async.put")
+            .booleanType()
+            .defaultValue(false);
+
     public static final String QUEUE_PREFIX = "queue.";
     public static final ConfigOption<String> QUEUE = ConfigOptions
             .key(QUEUE_PREFIX + "*")
@@ -112,7 +117,8 @@ public class JmsTableFactory implements DynamicTableSourceFactory, DynamicTableS
                 MQ_PORT,
                 MQ_QUEUE_MANAGER,
                 MQ_CHANNEL,
-                EXACTLY_ONCE);
+                EXACTLY_ONCE,
+                ASYNC_PUT);
     }
 
     @Override
@@ -136,6 +142,7 @@ public class JmsTableFactory implements DynamicTableSourceFactory, DynamicTableS
         String mqQueueManager = helper.getOptions().get(MQ_QUEUE_MANAGER);
         String mqChannel = helper.getOptions().get(MQ_CHANNEL);
         boolean exactlyOnce = helper.getOptions().get(EXACTLY_ONCE);
+        boolean asyncPut = helper.getOptions().get(ASYNC_PUT);
         Map<String, String> queueProps =
                 context.getCatalogTable().getOptions().entrySet().stream()
                         .filter(e -> e.getKey().startsWith(QUEUE_PREFIX))
@@ -209,6 +216,7 @@ public class JmsTableFactory implements DynamicTableSourceFactory, DynamicTableS
                 mqPort,
                 mqQueueManager,
                 mqChannel,
-                exactlyOnce);
+                exactlyOnce,
+                asyncPut);
     }
 }


### PR DESCRIPTION
## Summary
- add new config option `jms.async.put`
- propagate async flag to sink functions
- configure `MQConnectionFactory` with `WMQ_PUT_ASYNC_ALLOWED`
- document the new option in README

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d15c1e8448321ae018919aacfb450