### PR TITLE
Fix missing asyncPut variable in JmsTableFactory

### DIFF
--- a/src/main/java/com/example/jms/JmsTableFactory.java
+++ b/src/main/java/com/example/jms/JmsTableFactory.java
@@ -191,6 +191,7 @@ public class JmsTableFactory implements DynamicTableSourceFactory, DynamicTableS
         String mqQueueManager = helper.getOptions().get(MQ_QUEUE_MANAGER);
         String mqChannel = helper.getOptions().get(MQ_CHANNEL);
         boolean exactlyOnce = helper.getOptions().get(EXACTLY_ONCE);
+        boolean asyncPut = helper.getOptions().get(ASYNC_PUT);
         Map<String, String> queueProps =
                 context.getCatalogTable().getOptions().entrySet().stream()
                         .filter(e -> e.getKey().startsWith(QUEUE_PREFIX))


### PR DESCRIPTION
## Summary
- fix missing `asyncPut` option retrieval in `JmsTableFactory`

## Testing
- `mvn -q -DskipTests install` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d3f3a096c8321a78a3be859233ba8