### PR TITLE
Add debug logs for checkpoint commit

### DIFF
--- a/src/main/java/com/example/jms/JmsExactlyOnceSinkFunction.java
+++ b/src/main/java/com/example/jms/JmsExactlyOnceSinkFunction.java
@@ -213,11 +213,18 @@ public class JmsExactlyOnceSinkFunction extends TwoPhaseCommitSinkFunction<RowDa
 
     @Override
     protected void commit(JmsTransaction transaction) {
+        long start = System.currentTimeMillis();
+        System.out.println("Starting JMS commit...");
         try {
             if (transaction.session != null) {
                 transaction.session.commit();
             }
+            System.out.println(
+                    "JMS commit finished in "
+                            + (System.currentTimeMillis() - start)
+                            + " ms");
         } catch (Exception e) {
+            System.err.println("Failed to commit JMS transaction: " + e.getMessage());
             throw new RuntimeException("Failed to commit JMS transaction", e);
         } finally {
             cleanup(transaction);

--- a/src/main/java/com/example/jms/JmsExactlyOnceSourceFunction.java
+++ b/src/main/java/com/example/jms/JmsExactlyOnceSourceFunction.java
@@ -199,7 +199,14 @@ public class JmsExactlyOnceSourceFunction extends RichParallelSourceFunction<Row
     @Override
     public void notifyCheckpointComplete(long checkpointId) throws Exception {
         if (session != null) {
+            long start = System.currentTimeMillis();
+            System.out.println(
+                    "Committing JMS session for checkpoint " + checkpointId + "...");
             session.commit();
+            System.out.println(
+                    "JMS session commit finished in "
+                            + (System.currentTimeMillis() - start)
+                            + " ms");
         }
     }
 }


### PR DESCRIPTION
## Summary
- instrument commit paths in `JmsExactlyOnceSinkFunction` and `JmsExactlyOnceSourceFunction`
- print time taken during checkpoint commit

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin from central)*

------
https://chatgpt.com/codex/tasks/task_e_686d6e3b473c8321b024213e135d06b3