### PR TITLE
Include org.json dependency in uber JAR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,7 @@
                   <include>com.rabbitmq:amqp-client</include>
                   <include>com.ibm.mq:com.ibm.mq.allclient</include>
                   <include>io.netty:netty-*</include>
+                  <include>org.json:json</include>
                 </includes>
               </artifactSet>
 


### PR DESCRIPTION
## Summary
- include org.json:json in the shaded artifact set so the XML helper class is packaged

## Testing
- `mvn -q package` *(fails: Could not resolve Maven plugins due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6887404344808321b4973104a129351e